### PR TITLE
Dockerising the long-term pipeline

### DIFF
--- a/pipeline-long/Dockerfile
+++ b/pipeline-long/Dockerfile
@@ -1,9 +1,11 @@
-FROM python:latest
+FROM public.ecr.aws/lambda/python:latest
+
+WORKDIR ${LAMBDA_TASK_ROOT}
 
 COPY requirements.txt .
 
 RUN pip install -r requirements.txt
 
-COPY extract.py .
+COPY pipeline.py .
 
-CMD [ "python", "extract.py" ]
+CMD [ "pipeline.lambda_handler" ]

--- a/pipeline-long/Dockerfile
+++ b/pipeline-long/Dockerfile
@@ -7,5 +7,8 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 COPY pipeline.py .
+COPY extract.py .
+COPY transform.py .
+COPY load.py .
 
 CMD [ "pipeline.lambda_handler" ]


### PR DESCRIPTION
- Dockerised the long-term pipeline so that the lambda function can be run from the cloud.
- Made sure to copy over essential files that the main `pipeline.py` file relies on.